### PR TITLE
replace DEBUG macro with EXCCNN_TRACE + add usage requirement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,15 +14,13 @@ else()
     message(STATUS "Build config: ${CMAKE_BUILD_TYPE}")
 endif()
 
-# Debug option
-# FIXME: DEBUG should have a project prefix, e.g. EXCCNN_. we can also have
-# this be an INTERFACE target instead with this macro definition
-option(USE_DEBUG "Enter debug mode" OFF)
-if(USE_DEBUG)
-    add_definitions(-DDEBUG)
-    message(STATUS "Debug mode: ON")
+# debugging trace option for extra debugging output
+# note: since this is a build-time option it is of limited use to consumers
+option(EXCCNN_TRACE "Build with debugging traces" OFF)
+if(EXCCNN_TRACE)
+    message(STATUS "Debug tracing: Yes")
 else()
-    message(STATUS "Debug mode: OFF")
+    message(STATUS "Debug tracing: No")
 endif()
 
 # C++ standard requirements

--- a/include/connector.hpp
+++ b/include/connector.hpp
@@ -130,9 +130,9 @@ public:
 
   void update_weight(real_type gradient){
     if(std::abs(gradient) < 1.e-10){
-#ifdef DEBUG
+#ifdef EXCCNN_TRACE
       std::cout << "gradient = " << gradient << std::endl;
-#endif
+#endif  // EXCCNN_TRACE
       return;
     }
 

--- a/include/layer.hpp
+++ b/include/layer.hpp
@@ -66,13 +66,13 @@ public:
     layer_name = "numerical";
   }
 	void set_optimizer(const optimizer & o){
-#ifdef DEBUG
+#ifdef EXCCNN_TRACE
 		std::cout << "set_optimizer = " << o << std::endl;
-#endif
+#endif  // EXCCNN_TRACE
 		layer_optimizer = o;
-#ifdef DEBUG
+#ifdef EXCCNN_TRACE
 		std::cout << "after set_optimizer = " << layer_optimizer << std::endl;
-#endif
+#endif  // EXCCNN_TRACE
 	}
 
   // ostream operator
@@ -108,9 +108,9 @@ public:
       for (cnn::int_type k = 0; k < prev.size(); k ++) {
         sum = sum + weights.w[it{l, j, k}].weight*prev[k];
         //sum = sum + weights.w[it{l, j, k}].weight*prev[k] + weights.w[it{l, j, k}].bias;
-#ifdef DEBUG
+#ifdef EXCCNN_TRACE
         printf("layer::update_forward:: l=%d,j=%d,k=%d: prev[k]=%f sum=%f \n", l, j, k, prev[k], sum);
-#endif
+#endif  // EXCCNN_TRACE
       }
       neurons[j].value = layer_optimizer.activate(sum);
       //printf("%d: %f \n", j, neurons[j].value);
@@ -139,14 +139,14 @@ public:
     for (cnn::int_type j = 0; j < size(); j ++) {
       for (cnn::int_type k = 0; k < prev.size(); k ++) {
         real_type gradient = delta[j]*prev[k];
-#ifdef DEBUG
+#ifdef EXCCNN_TRACE
         printf("update_backward::before l=%d,j=%d,k=%d: weight=%f gradient=%f\n", l,j,k, weights.w[it{l, j, k}].weight, gradient);
-#endif
+#endif  // EXCCNN_TRACE
         weights.w[it{l, j, k}].update_weight(gradient); // grad w_jk = delta_j * prev_k
         weights.w[it{l, j, k}].update_bias(delta[j]); // grad b_j = delta_j
-#ifdef DEBUG
+#ifdef EXCCNN_TRACE
         printf("update_backward::after l=%d,j=%d,k=%d: weight=%f \n", l,j,k, weights.w[it{l, j, k}].weight);
-#endif
+#endif  // EXCCNN_TRACE
       }
     }
 
@@ -163,7 +163,6 @@ public:
   }
 };
 
-};
+}  // namespace cnn
 
-#endif
-
+#endif  // LAYER_HPP

--- a/include/nn.hpp
+++ b/include/nn.hpp
@@ -76,13 +76,13 @@ public:
   virtual bool initialize() = 0; // Pure virtual function so this class must be extended.
 
 	void set_optimizer(const optimizer & o){
-#ifdef DEBUG
+#ifdef EXCCNN_TRACE
 		std::cout << "nn::set_optimizer = " << o << std::endl;
-#endif
+#endif  // EXCCNN_TRACE
 		for(int_type i = 0; i < layers.size(); i ++){
-#ifdef DEBUG
+#ifdef EXCCNN_TRACE
 			std::cout << "layers[" << i << "].set_optimizer = " << o << std::endl;
-#endif
+#endif  // EXCCNN_TRACE
 			layers[i].set_optimizer(o);
 		}
 	}
@@ -101,24 +101,24 @@ public:
 
   void update_forward(void){
 
-#ifdef DEBUG
+#ifdef EXCCNN_TRACE
 		std::cout << "input: " << layers[0];
-#endif
+#endif  // EXCCNN_TRACE
     //iteratively update the neural network forward from 2nd layer to last layer
     //l = 0 is first layer, l = 1 is 2nd layer
     auto n_layers = layers.size();
     for (int_type l = 1; l < n_layers ; l++){
       layers[l].update_forward(l, layers[l-1], weights);
-#ifdef DEBUG
+#ifdef EXCCNN_TRACE
       std::cout << "output: l=" << l << " : " << layers[l];
-#endif
+#endif  // EXCCNN_TRACE
     }
   }
 
   void update_backward(void) {
-#ifdef DEBUG
+#ifdef EXCCNN_TRACE
     std::cout << "prior to update_backward weights: \n" << weights;
-#endif
+#endif  // EXCCNN_TRACE
     // Calculate delta from output layer and expected value
     std::vector<cnn::real_type> delta;
     std::vector<cnn::real_type> prev_delta;
@@ -128,9 +128,9 @@ public:
     for (auto j = 0u; j < layer_neuron_size; j ++){
       //delta[j] = 2*(layers[1][j]-expected[j])*sigmoid(layers[1][j])*(1 - sigmoid(layers[1][j]));
       delta[j] = (layers[n_layers-1][j]-expected[j]);
-#ifdef DEBUG
+#ifdef EXCCNN_TRACE
       printf("l=%d, j=%d: %f %f delta[j]=%f\n", n_layers-1, j, layers[n_layers-1][j], expected[j], delta[j]);
-#endif
+#endif  // EXCCNN_TRACE
     }
 
     //iteratively update the neural network backward from last layer to 2nd layer
@@ -139,17 +139,17 @@ public:
       layers[l].update_backward(l, layers[l-1], weights, delta, prev_delta);
       std::swap(delta, prev_delta); // efficiently swap the underlying memory pointer without actually copying
     }
-#ifdef DEBUG
+#ifdef EXCCNN_TRACE
     std::cout << "after update_backward weights: \n" << weights;
-#endif
+#endif  // EXCCNN_TRACE
   }
 
   void update(const cnn::int_type max_iter=1000, const cnn::real_type threshold=1.e-6) {
     cnn::int_type iter = 0;
-#ifdef DEBUG
+#ifdef EXCCNN_TRACE
     std::cout << "expected = " << expected << std::endl;
     std::cout << "layers.back().values() = " << layers.back() << std::endl;
-#endif
+#endif  // EXCCNN_TRACE
     cnn::real_type mse = cost_function(layers.back().values(), expected.values());
     if(epoch_frequency < 100)
       epoch_frequency = 100;
@@ -180,12 +180,12 @@ public:
         for (auto& weight_pair : weights.w) {
             weight_pair.second.reset(learning_rate, momentum, decay);
         }
-#ifdef DEBUG
+#ifdef EXCCNN_TRACE
         std::cout << "Reset learning parameters:"
                   << "\n  Learning rate: " << learning_rate
                   << "\n  Momentum: " << momentum
                   << "\n  Decay: " << decay << std::endl;
-#endif
+#endif  // EXCCNN_TRACE
     }
 
     // Method to adjust learning rate during training
@@ -194,9 +194,9 @@ public:
             auto& connector = weight_pair.second;
             connector.learning_rate *= factor;
         }
-#ifdef DEBUG
+#ifdef EXCCNN_TRACE
         std::cout << "Adjusted learning rate by factor: " << factor << std::endl;
-#endif
+#endif  // EXCCNN_TRACE
     }
 
     // Get current learning rate (average across all connectors)
@@ -227,9 +227,9 @@ public:
         // Reset expected values
         std::fill(expected.values().begin(), expected.values().end(), real_type{});
 
-#ifdef DEBUG
+#ifdef EXCCNN_TRACE
         std::cout << "Network reset completed" << std::endl;
-#endif
+#endif  // EXCCNN_TRACE
     }
 
     // Optional: Add a method to reset weights to their initial values
@@ -250,13 +250,13 @@ public:
                 }
             }
         }
-#ifdef DEBUG
+#ifdef EXCCNN_TRACE
         std::cout << "Weights reinitialized" << std::endl;
-#endif
+#endif  // EXCCNN_TRACE
     }
 
 };
 
-};
+}  // namespace cnn
 
-#endif
+#endif  // NN_HPP

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,6 +2,11 @@ cmake_minimum_required(VERSION ${CMAKE_MINIMUM_REQUIRED_VERSION})
 
 # cnnlib: CNN support library
 add_library(cnnlib SHARED functions.cpp mnist.cpp utils.cpp)
+# if debugging trace required build with EXCCNN_TRACE defined. it is also added
+# as a usage requirement so one can use #ifdefs to check for trace on/off
+if(EXCCNN_TRACE)
+    target_compile_definitions(cnnlib PUBLIC EXCCNN_TRACE)
+endif()
 target_include_directories(cnnlib PUBLIC ${PROJECT_SOURCE_DIR}/include)
 target_link_libraries(cnnlib PRIVATE ZLIB::ZLIB)
 # note: header interface is currently a mess and Boost dependency is transitive

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -71,14 +71,15 @@ cnn::real_type cross_entropy_loss(const std::vector<cnn::real_type>& predicted,
         loss -= target[i] * std::log(softmax_output[i]);
     }
 
-#ifndef DEBUG
+// FIXME: should not always be on. kept for now to make tests more informative
+#if 1
     std::cout << "Cross Entropy Loss Calculation:\n";
     std::cout << "Predicted (after softmax): ";
     for (const auto& p : softmax_output) std::cout << p << " ";
     std::cout << "\nTarget: ";
     for (const auto& t : target) std::cout << t << " ";
-    std::cout << "\nLoss: " << loss << "\n";
-#endif
+    std::cout << "\nLoss: " << loss << std::endl;
+#endif  // 1
 
     return loss;
 }

--- a/test/test_cnn6.cpp
+++ b/test/test_cnn6.cpp
@@ -86,9 +86,9 @@ bool simple_neural_network::initialize() {
 /* reset the input to the image file pixel value */
 bool
 simple_neural_network::reset_input(const std::vector<std::vector<cnn::real_type>> & input, const int index){
-#ifdef DEBUG
+#ifdef EXCCNN_TRACE
 	std::cout << layers[0].size() << " " << input[index].size();
-#endif
+#endif  // EXCCNN_TRACE
 	assert(this->layers[0].size() == input[index].size());
 	for(cnn::int_type i = 0; i < this->layers[0].size(); i ++)
 		this->layers[0][i]=input[index][i];
@@ -101,9 +101,9 @@ simple_neural_network::reset_expected(const int & index){
 	for(cnn::int_type i = 0; i < this->expected.size(); i ++)
 		this->expected[i]=0;
         this->expected[index]=1;
-#ifdef DEBUG
+#ifdef EXCCNN_TRACE
 	std::cout << "expected = " << this->expected[index] << std::endl;
-#endif
+#endif  // EXCCNN_TRACE
 	return true;
 }
 
@@ -146,7 +146,7 @@ int main(int argc, char* argv[]) {
         std::cout << "Successfully read " << pixelValues.size() << " images with "
                   << pixelValues[0].size() << " pixels each and " << labels.size()
                   << " labels." << std::endl;
-#ifdef DEBUG
+#ifdef EXCCNN_TRACE
         // Debug output for first digit
         std::cout << "\nFirst digit (label: " << labels[0] << "):\n";
         for (int i = 0; i < 28; i++) {
@@ -166,7 +166,7 @@ int main(int argc, char* argv[]) {
             std::cout << "\n";
         }
         std::cout << "\n\n";
-#endif
+#endif  // EXCCNN_TRACE
     } catch (const std::exception& e) {
         std::cerr << e.what() << std::endl;
         return 1;
@@ -179,7 +179,7 @@ int main(int argc, char* argv[]) {
         }
     }
 
-#ifdef DEBUG
+#ifdef EXCCNN_TRACE
     // Debug: Print first few normalized pixels
     std::cout << "First few normalized digit: ";
     for (int i = 0; i < 28; ++i) {
@@ -189,7 +189,7 @@ int main(int argc, char* argv[]) {
         std::cout << "\n";
     }
     std::cout << "\n";
-#endif
+#endif  // EXCCNN_TRACE
     simple_neural_network nn;
 
     if (mode == "--train" || mode == "--resume") {
@@ -209,9 +209,9 @@ int main(int argc, char* argv[]) {
             nn.reset_input(pixelValues, idx);
             nn.reset_expected(labels[idx]);
             nn.reset_learning_parameters();
-#ifdef DEBUG
+#ifdef EXCCNN_TRACE
             std::cout << nn << std::endl;
-#endif
+#endif  // EXCCNN_TRACE
             nn.update();
         }
 
@@ -223,9 +223,10 @@ int main(int argc, char* argv[]) {
         std::ifstream ifs{"trained_mnist.yml"};
         boost::archive::yml_iarchive yia{ifs};
         yia >> NVP(nn);
-#ifndef DEBUG
+// FIXME: unsure if this should be #ifdef instead
+#ifndef EXCCNN_TRACE
         std::cout << "nn = " << nn << std::endl;
-#endif
+#endif  // EXCCNN_TRACE
         std::cout << "nn.print_weight_statistics() = " << std::endl;
         nn.print_weight_statistics();
 


### PR DESCRIPTION
## Summary

Replaces the `DEBUG` macro with `EXCCNN_TRACE` when enabling build-time inclusion of extra debugging traces.

The `DEBUG` macro is defined during build time to enable extra debugging but the name is too generic and can clash with other libraries that might also define this symbol, so we replace the name with `EXCCNN_TRACE`. Furthermore, we make the macro definition a usage requirement of `cnnlib` instead of defining it globally during build, so any use of the `cnnlib` library target will automatically get `EXCCNN_TRACE` added to its compile flags appropriately.