### PR TITLE
clean up + enhance class serialization

### DIFF
--- a/include/connection.hpp
+++ b/include/connection.hpp
@@ -1,47 +1,39 @@
 #ifndef CONNECTION_HPP
 #define CONNECTION_HPP
 
-#include "yml_oarchive.hpp"
-#include "yml_iarchive.hpp"
-
-#include <boost/serialization/vector.hpp>
-#include <boost/serialization/utility.hpp> // serialize pair
-#include <boost/serialization/array.hpp>
-#include <boost/serialization/set.hpp>
-#include <boost/serialization/optional.hpp> // serialize boost::optional
-
-#include <boost/numeric/ublas/matrix.hpp>
-#include <boost/numeric/ublas/io.hpp>
 #include <vector>
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <cassert>
+#include <boost/serialization/access.hpp>
+#include <boost/serialization/nvp.hpp>
+#include <boost/serialization/vector.hpp>
 
 #include "typedef.hpp"
 #include "connector.hpp"
 
-#define NVP(a) BOOST_SERIALIZATION_NVP(a)
+namespace cnn {
 
-using namespace boost::numeric::ublas;
-
-namespace cnn{
-
-class Connection{
-
+class Connection {
 public:
+  // TODO: can be private if Connector has operator[] and iterator support
   std::vector<cnn::Connector> weights;
 
-  friend std::ostream & operator << (std::ostream & stream, const Connection & con_);
-	template<class Ar>
-	void serialize(Ar& ar, unsigned){
-		ar & NVP(weights);
+private:
+  friend class boost::serialization::access;
+
+	template <typename Ar>
+	void serialize(Ar& ar, unsigned /*version*/)
+  {
+		ar & BOOST_SERIALIZATION_NVP(weights);
 	}
-  bool operator == (Connection const & con_) const { return con_.weights.size() == weights.size() ; }
 
-  Connection(){
-
+public:
+  // TODO: compare Connectors as well
+  bool operator==(Connection const & con_) const
+  {
+    return con_.weights.size() == weights.size();
   }
+
+  Connection() = default;
 
   Connection(const std::vector<cnn::Connector> & _weights){
      weights = _weights;
@@ -63,11 +55,8 @@ public:
     const real_type & /*next*/) {
 
   }
-
-private:
 };
 
-};
+}  // namespace cnn
 
-#endif
-
+#endif  // CONNECTION_HPP

--- a/include/connection.hpp
+++ b/include/connection.hpp
@@ -20,11 +20,11 @@ public:
 private:
   friend class boost::serialization::access;
 
-	template <typename Ar>
-	void serialize(Ar& ar, unsigned /*version*/)
+  template <typename Ar>
+  void serialize(Ar& ar, unsigned /*version*/)
   {
-		ar & BOOST_SERIALIZATION_NVP(weights);
-	}
+    ar & BOOST_SERIALIZATION_NVP(weights);
+  }
 
 public:
   // TODO: compare Connectors as well

--- a/include/connector.hpp
+++ b/include/connector.hpp
@@ -1,42 +1,27 @@
 #ifndef CONNECTOR_HPP
 #define CONNECTOR_HPP
 
-#include "yml_oarchive.hpp"
-#include "yml_iarchive.hpp"
-
-#include <boost/serialization/vector.hpp>
-#include <boost/serialization/utility.hpp> // serialize pair
-#include <boost/serialization/array.hpp>
-#include <boost/serialization/set.hpp>
-#include <boost/serialization/optional.hpp> // serialize boost::optional
-
-#include <boost/numeric/ublas/matrix.hpp>
-#include <boost/numeric/ublas/io.hpp>
+#include <algorithm>
+#include <cmath>
+#include <ostream>
 #include <vector>
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <cassert>
-#include <cmath>
+#include <boost/serialization/access.hpp>
+#include <boost/serialization/nvp.hpp>
 
 #include "typedef.hpp"
 #include "functions.hpp"
 
-#define NVP(a) BOOST_SERIALIZATION_NVP(a)
+namespace cnn {
 
-using namespace boost::numeric::ublas;
-
-namespace cnn{
-
-  enum class InitType {
-      KAIMING,
-      XAVIER,
-      ORTHOGONAL
-  };
+enum class InitType {
+  KAIMING,
+  XAVIER,
+  ORTHOGONAL
+};
 
 // Connector stores the weight information and information to update weight
-class Connector{
-
+class Connector {
 public:
   // next layer number: l
   int layer;
@@ -58,16 +43,30 @@ public:
   // for lr adjustment
   real_type old_gradient;
   int_type  iter;
+
 private:
   InitType init_type;
-  static std::vector<std::vector<real_type>> orthogonal_matrix;
-  static int orthogonal_matrix_index;
+  static inline std::vector<std::vector<real_type>> orthogonal_matrix;
+  static inline int orthogonal_matrix_index = 0;
+
+private:
+  friend class boost::serialization::access;
+
+  template <typename Ar>
+  void serialize(Ar& ar, unsigned /*version*/)
+  {
+    ar &
+      BOOST_SERIALIZATION_NVP(layer) &
+      BOOST_SERIALIZATION_NVP(input_index) &
+      BOOST_SERIALIZATION_NVP(output_index) &
+      BOOST_SERIALIZATION_NVP(weight) &
+      BOOST_SERIALIZATION_NVP(bias) &
+      BOOST_SERIALIZATION_NVP(learning_rate) &
+      BOOST_SERIALIZATION_NVP(momentum) &
+      BOOST_SERIALIZATION_NVP(decay);
+  }
 
 public:
-  template<class Ar>
-  void serialize(Ar& ar, unsigned){
-    ar & NVP(layer) & NVP(input_index) & NVP(output_index) & NVP(weight) & NVP(bias) & NVP(learning_rate) & NVP(momentum) & NVP(decay);
-  }
   bool operator==(Connector const& c_) const{
    return c_.weight        == weight
        && c_.layer         == layer
@@ -166,13 +165,12 @@ public:
   }
 
   // ostream operator
-  friend std::ostream& operator<< (std::ostream& stream, const Connector & n) {
-
-    std::cout << "(" << n.layer << "," << n.input_index << "," << n.output_index <<  "): "
-              << n.weight << ' ' << n.bias << ' '
-              << n.learning_rate << ' ' << n.momentum  << std::endl;
-
-    return stream;
+  friend std::ostream& operator<<(std::ostream& out, const Connector& n)
+  {
+    return out <<
+      "(" << n.layer << "," << n.input_index << "," << n.output_index <<  "): "
+      << n.weight << ' ' << n.bias << ' ' << n.learning_rate << ' ' <<
+      n.momentum  << "\n";
   }
 
 private:
@@ -190,11 +188,6 @@ private:
   }
 };
 
-// Initialize static members
-std::vector<std::vector<real_type>> Connector::orthogonal_matrix;
-int Connector::orthogonal_matrix_index = 0;
+}  // namespace cnn
 
-};
-
-#endif
-
+#endif  // CONNECTOR_HPP

--- a/include/functions.hpp
+++ b/include/functions.hpp
@@ -53,12 +53,6 @@ real_type derivative_softmax(const real_type x);
 struct activation {
   unary_real_function f;  // function
   unary_real_function g;  // gradient
-
-  // convert into std::pair for std::tie interop
-  std::pair<unary_real_function, unary_real_function> pair() const noexcept
-  {
-    return {f, g};
-  }
 };
 
 /**
@@ -102,10 +96,6 @@ real_type hinge_loss(const std::vector<real_type>& predicted,
 EXCCNN_PUBLIC
 real_type kl_divergence_loss(const std::vector<real_type>& predicted,
                              const std::vector<real_type>& target);
-
-// TODO: deprecate in favor of inner_product_real_function
-typedef real_type (*CostFunctionPointer)(const std::vector<real_type>&,
-                                         const std::vector<real_type>&);
 
 /**
  * Obtain the cost function given a string identifier.

--- a/include/functions.hpp
+++ b/include/functions.hpp
@@ -2,6 +2,8 @@
 #define FUNCTIONS_HPP
 
 #include <optional>
+#include <string_view>
+#include <utility>
 #include <vector>
 
 #include "exccnn/dllexport.h"
@@ -45,6 +47,28 @@ real_type softmax(const real_type x);
 EXCCNN_PUBLIC
 real_type derivative_softmax(const real_type x);
 
+/**
+ * Structure holding an activation function and its derivative.
+ */
+struct activation {
+  unary_real_function f;  // function
+  unary_real_function g;  // gradient
+
+  // convert into std::pair for std::tie interop
+  std::pair<unary_real_function, unary_real_function> pair() const noexcept
+  {
+    return {f, g};
+  }
+};
+
+/**
+ * Obtain the activation + derivative function given a string identifier.
+ *
+ * @param name Activation name, e.g. `"linear"`, `"relu"`, etc.
+ */
+EXCCNN_PUBLIC
+activation get_activation(std::string_view name);
+
 // Optional: Vector version of softmax (often useful)
 EXCCNN_PUBLIC
 std::vector<real_type> softmax_vector(const std::vector<real_type>& x);
@@ -79,8 +103,17 @@ EXCCNN_PUBLIC
 real_type kl_divergence_loss(const std::vector<real_type>& predicted,
                              const std::vector<real_type>& target);
 
+// TODO: deprecate in favor of inner_product_real_function
 typedef real_type (*CostFunctionPointer)(const std::vector<real_type>&,
                                          const std::vector<real_type>&);
+
+/**
+ * Obtain the cost function given a string identifier.
+ *
+ * @param name Cost function name, i.e. "hinge_loss", "mse_loss", etc.
+ */
+EXCCNN_PUBLIC
+inner_product_real_function get_cost_function(std::string_view name);
 
 }  // namespace cnn
 

--- a/include/functions.hpp
+++ b/include/functions.hpp
@@ -115,14 +115,6 @@ typedef real_type (*CostFunctionPointer)(const std::vector<real_type>&,
 EXCCNN_PUBLIC
 inner_product_real_function get_cost_function(std::string_view name);
 
-/**
- * Obtain the cost function identifier given the cost function.
- *
- * @param func Cost function
- */
-EXCCNN_PUBLIC
-std::string_view get_cost_function_name(inner_product_real_function func);
-
 }  // namespace cnn
 
 #endif  // FUNCTIONS_HPP

--- a/include/functions.hpp
+++ b/include/functions.hpp
@@ -115,6 +115,14 @@ typedef real_type (*CostFunctionPointer)(const std::vector<real_type>&,
 EXCCNN_PUBLIC
 inner_product_real_function get_cost_function(std::string_view name);
 
+/**
+ * Obtain the cost function identifier given the cost function.
+ *
+ * @param func Cost function
+ */
+EXCCNN_PUBLIC
+std::string_view get_cost_function_name(inner_product_real_function func);
+
 }  // namespace cnn
 
 #endif  // FUNCTIONS_HPP

--- a/include/layer.hpp
+++ b/include/layer.hpp
@@ -1,36 +1,30 @@
 #ifndef LAYER_HPP
 #define LAYER_HPP
 
-#include "yml_oarchive.hpp"
-#include "yml_iarchive.hpp"
-
-#include <boost/serialization/vector.hpp>
-#include <boost/serialization/utility.hpp> // serialize pair
-#include <boost/serialization/array.hpp>
-#include <boost/serialization/set.hpp>
-#include <boost/serialization/optional.hpp> // serialize boost::optional
-
-#include <vector>
-#include <algorithm>
-
 #include <cassert>
+#include <cstdio>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include <boost/serialization/access.hpp>
+#include <boost/serialization/string.hpp>
+#include <boost/serialization/vector.hpp>
 
 #include "typedef.hpp"
 #include "neuron.hpp"
-#include "connection.hpp"
-#include "weights.hpp"
-#include "sparse_array.hpp"
-#include "utils.hpp"
 #include "optimizer.hpp"
-#include "functions.hpp"
+#include "weights.hpp"
 
-#define NVP(a) BOOST_SERIALIZATION_NVP(a)
-
-namespace cnn{
+namespace cnn {
 
 //class Neuron; // Forward declaration
 
-class Layer{
+class Layer {
+public:
+  std::string         layer_name; // numerical, image, video, audio
+
+private:
   // stores a list of neurons
   std::vector<Neuron> neurons;
   int                 layer_type; //-1: input, 0: middle, 1: output
@@ -38,14 +32,25 @@ class Layer{
   std::vector<real_type> delta; // save a copy of delta for efficient back propogation in recursive algorithm
   optimizer           layer_optimizer;
 
-public:
-  std::string         layer_name; // numerical, image, video, audio
-	template<class Ar>
-	void serialize(Ar& ar, unsigned){
-		ar & NVP(layer_type) & NVP(layer_name) & NVP(layer_size) & NVP(neurons) & NVP(delta) & NVP(layer_optimizer);
+  // enable serialize() access
+  friend class boost::serialization::access;
+
+  template <typename Ar>
+	void serialize(Ar& ar, unsigned /*version*/)
+  {
+		ar &
+      BOOST_SERIALIZATION_NVP(layer_type) &
+      BOOST_SERIALIZATION_NVP(layer_name) &
+      BOOST_SERIALIZATION_NVP(layer_size) &
+      BOOST_SERIALIZATION_NVP(neurons) &
+      BOOST_SERIALIZATION_NVP(delta) &
+      BOOST_SERIALIZATION_NVP(layer_optimizer);
     //neurons.resize(layer_size);
 	}
-	bool operator==(Layer const& l_) const{
+
+public:
+	bool operator==(Layer const& l_) const
+  {
     return l_.layer_type==this->layer_type
         && l_.layer_name == this->layer_name
         && l_.layer_size == this->layer_size;
@@ -87,14 +92,14 @@ public:
 	}
 
   // ostream operator
-  friend std::ostream& operator<< (std::ostream& stream, const Layer & layer) {
-
-		std::cout << layer.layer_name << " : layer_type = " << layer.layer_type << std::endl;
-		std::cout << "layer_optimizer = " << layer.layer_optimizer << std::endl;
-		for(int i = 0; i < layer.neurons.size(); i ++)
-			std::cout << "layer[" << i <<"]" << layer.neurons[i];
-
-    return stream;
+  friend std::ostream& operator<< (std::ostream& out, const Layer& layer)
+  {
+		out <<
+      layer.layer_name << " : layer_type = " << layer.layer_type << "\n" <<
+      "layer_optimizer = " << layer.layer_optimizer << "\n";
+		for (auto i = 0u; i < layer.neurons.size(); i++)
+			out << "layer[" << i << "]" << layer.neurons[i];
+    return out;
   }
 
   // return the size of the layer: how many neurons
@@ -120,11 +125,11 @@ public:
         sum = sum + weights.w[it{l, j, k}].weight*prev[k];
         //sum = sum + weights.w[it{l, j, k}].weight*prev[k] + weights.w[it{l, j, k}].bias;
 #ifdef DEBUG
-        printf("layer::update_forward:: l=%d,j=%d,k=%d: prev[k]=%f sum=%f \n", l, j, k, prev[k], sum);
+        std::printf("layer::update_forward:: l=%d,j=%d,k=%d: prev[k]=%f sum=%f \n", l, j, k, prev[k], sum);
 #endif
       }
-      neurons[j].value = layer_optimizer.activate(sum);
-      //printf("%d: %f \n", j, neurons[j].value);
+      neurons[j].value = layer_optimizer(sum);
+      //std::printf("%d: %f \n", j, neurons[j].value);
     }
 
     return 0;
@@ -143,7 +148,7 @@ public:
       for(int_type j = 1; j < size(); j ++){
         prev_delta[k] +=  weights.w[it{l, j, k}].weight * delta[j];
       }
-      prev_delta[k] *= layer_optimizer.derivative(prev[k]);
+      prev_delta[k] *= layer_optimizer.grad(prev[k]);
     }
 
     // Update weights in current layer
@@ -151,12 +156,12 @@ public:
       for (cnn::int_type k = 0; k < prev.size(); k ++) {
         real_type gradient = delta[j]*prev[k];
 #ifdef DEBUG
-        printf("update_backward::before l=%d,j=%d,k=%d: weight=%f gradient=%f\n", l,j,k, weights.w[it{l, j, k}].weight, gradient);
+        std::printf("update_backward::before l=%d,j=%d,k=%d: weight=%f gradient=%f\n", l,j,k, weights.w[it{l, j, k}].weight, gradient);
 #endif
         weights.w[it{l, j, k}].update_weight(gradient); // grad w_jk = delta_j * prev_k
         weights.w[it{l, j, k}].update_bias(delta[j]); // grad b_j = delta_j
 #ifdef DEBUG
-        printf("update_backward::after l=%d,j=%d,k=%d: weight=%f \n", l,j,k, weights.w[it{l, j, k}].weight);
+        std::printf("update_backward::after l=%d,j=%d,k=%d: weight=%f \n", l,j,k, weights.w[it{l, j, k}].weight);
 #endif
       }
     }
@@ -174,7 +179,6 @@ public:
   }
 };
 
-};
+}  // namespace cnn
 
-#endif
-
+#endif  // LAYER_HPP

--- a/include/layer.hpp
+++ b/include/layer.hpp
@@ -65,6 +65,17 @@ public:
     layer_type = 0;
     layer_name = "numerical";
   }
+
+  /**
+   * Set the layer activation function and derivative.
+   *
+   * @param name Activation function name, e.g. `"relu"`, `"linear"`
+   */
+  void set_optimizer(std::string name)
+  {
+    set_optimizer(optimizer{std::move(name)});
+  }
+
 	void set_optimizer(const optimizer & o){
 #ifdef DEBUG
 		std::cout << "set_optimizer = " << o << std::endl;

--- a/include/layer.hpp
+++ b/include/layer.hpp
@@ -36,9 +36,9 @@ private:
   friend class boost::serialization::access;
 
   template <typename Ar>
-	void serialize(Ar& ar, unsigned /*version*/)
+  void serialize(Ar& ar, unsigned /*version*/)
   {
-		ar &
+    ar &
       BOOST_SERIALIZATION_NVP(layer_type) &
       BOOST_SERIALIZATION_NVP(layer_name) &
       BOOST_SERIALIZATION_NVP(layer_size) &
@@ -46,10 +46,10 @@ private:
       BOOST_SERIALIZATION_NVP(delta) &
       BOOST_SERIALIZATION_NVP(layer_optimizer);
     //neurons.resize(layer_size);
-	}
+  }
 
 public:
-	bool operator==(Layer const& l_) const
+  bool operator==(Layer const& l_) const
   {
     return l_.layer_type==this->layer_type
         && l_.layer_name == this->layer_name
@@ -94,11 +94,11 @@ public:
   // ostream operator
   friend std::ostream& operator<< (std::ostream& out, const Layer& layer)
   {
-		out <<
+    out <<
       layer.layer_name << " : layer_type = " << layer.layer_type << "\n" <<
       "layer_optimizer = " << layer.layer_optimizer << "\n";
-		for (auto i = 0u; i < layer.neurons.size(); i++)
-			out << "layer[" << i << "]" << layer.neurons[i];
+    for (auto i = 0u; i < layer.neurons.size(); i++)
+      out << "layer[" << i << "]" << layer.neurons[i];
     return out;
   }
 

--- a/include/layer.hpp
+++ b/include/layer.hpp
@@ -143,7 +143,7 @@ public:
       for(int_type j = 1; j < size(); j ++){
         prev_delta[k] +=  weights.w[it{l, j, k}].weight * delta[j];
       }
-      prev_delta[k] *= layer_optimizer.derivative_funcptr(prev[k]);
+      prev_delta[k] *= layer_optimizer.derivative(prev[k]);
     }
 
     // Update weights in current layer

--- a/include/neuron.hpp
+++ b/include/neuron.hpp
@@ -1,66 +1,46 @@
 #ifndef NEURON_HPP
 #define NEURON_HPP
 
-#include "yml_oarchive.hpp"
-#include "yml_iarchive.hpp"
+#include <ostream>
 
-#include <boost/serialization/vector.hpp>
-#include <boost/serialization/utility.hpp> // serialize pair
-#include <boost/serialization/array.hpp>
-#include <boost/serialization/set.hpp>
-#include <boost/serialization/optional.hpp> // serialize boost::optional
-
-#include <boost/numeric/ublas/matrix.hpp>
-#include <boost/numeric/ublas/io.hpp>
-#include <vector>
-
-#include <stdio.h> 
-#include <stdlib.h> 
-#include <cassert>
+#include <boost/serialization/access.hpp>
+#include <boost/serialization/nvp.hpp>
 
 #include "typedef.hpp"
 
-#define NVP(a) BOOST_SERIALIZATION_NVP(a)
+namespace cnn {
 
-using namespace boost::numeric::ublas;
-
-namespace cnn{
-
-
-class Neuron{
-
+// TODO: document + add arithmetic operators
+class Neuron {
 public:
-  real_type value;
-
-  real_type get() const {
-    return value;
-  }
-  void set_value(const real_type value_) {
-    value = value_;
-  }
-	template<class Ar>
-	void serialize(Ar& ar, unsigned){
-		ar &  NVP(value);
-	}
-  Neuron(){ 
-     default_initialize();
-  }
+  real_type value{};
 
   // ostream operator
-  friend std::ostream& operator<< (std::ostream& stream, const Neuron & n) {
-
-		std::cout  << " : value = " << n.value << std::endl;
-
-    return stream;
+  friend std::ostream& operator<<(std::ostream& out, const Neuron& n)
+  {
+    // TODO: maybe consider not writing a newline
+		return out << " : value = " << n.value << "\n";
   }
-  
+
+  /**
+   * Return a `Neuron` with a negated value.
+   */
+  auto operator-() const noexcept
+  {
+    return Neuron{-value};
+  }
+
 private:
-  void default_initialize(){
-    value = 0.;
-  }
+  // enable serialize() access
+  friend boost::serialization::access;
+
+  template <typename Ar>
+	void serialize(Ar& ar, unsigned /*version*/)
+  {
+		ar & BOOST_SERIALIZATION_NVP(value);
+	}
 };
 
-};
+}  // namespace cnn
 
-#endif
-
+#endif  // NEURON_HPP

--- a/include/neuron.hpp
+++ b/include/neuron.hpp
@@ -19,7 +19,7 @@ public:
   friend std::ostream& operator<<(std::ostream& out, const Neuron& n)
   {
     // TODO: maybe consider not writing a newline
-		return out << " : value = " << n.value << "\n";
+    return out << " : value = " << n.value << "\n";
   }
 
   /**
@@ -35,10 +35,10 @@ private:
   friend boost::serialization::access;
 
   template <typename Ar>
-	void serialize(Ar& ar, unsigned /*version*/)
+  void serialize(Ar& ar, unsigned /*version*/)
   {
-		ar & BOOST_SERIALIZATION_NVP(value);
-	}
+    ar & BOOST_SERIALIZATION_NVP(value);
+  }
 };
 
 }  // namespace cnn

--- a/include/nn.hpp
+++ b/include/nn.hpp
@@ -1,6 +1,7 @@
 #ifndef NN_HPP
 #define NN_HPP
 
+#include <boost/serialization/access.hpp>
 #include <boost/serialization/nvp.hpp>
 #include <boost/serialization/split_member.hpp>
 #include <boost/serialization/vector.hpp>
@@ -26,19 +27,25 @@ namespace cnn {
 class NeuralNetwork {
 public:
   //////////////////////////////////////////////////////////////////////////////
-  int n_layers;
+  // TODO: these members should be private
+  int n_layers{};
 	Layer expected;
 	std::vector<Layer> layers;
   Weights weights;
-  int_type epoch_frequency;
-  inner_product_real_function cost_function;
+  int_type epoch_frequency{};
+
+private:
+  std::string cost_function_name_;               // cost function name
+  inner_product_real_function cost_function_{};  // cost function
   //////////////////////////////////////////////////////////////////////////////
+
+  // enable save/load access
+  friend class boost::serialization::access;
 
   /**
    * Boost serialization function.
    *
-   * This serializes all the public members. The cost function is mapped to a
-   * string name that is written to the archive instead.
+   * This serializes all the public members and the cost function name.
    *
    * @tparam Ar Boost.Serialization output archive
    *
@@ -52,10 +59,8 @@ public:
       BOOST_SERIALIZATION_NVP(expected) &
       BOOST_SERIALIZATION_NVP(layers) &
       BOOST_SERIALIZATION_NVP(weights) &
-      BOOST_SERIALIZATION_NVP(epoch_frequency);
-    // save cost function identifier
-    std::string cf_name{get_cost_function_name(cost_function)};
-    ar & boost::serialization::make_nvp("cost_function", cf_name);
+      BOOST_SERIALIZATION_NVP(epoch_frequency) &
+      boost::serialization::make_nvp("cost_function", cost_function_name_);
   }
 
   /**
@@ -75,16 +80,16 @@ public:
       BOOST_SERIALIZATION_NVP(expected) &
       BOOST_SERIALIZATION_NVP(layers) &
       BOOST_SERIALIZATION_NVP(weights) &
-      BOOST_SERIALIZATION_NVP(epoch_frequency);
-    // load cost function from identifier
-    std::string cf_name;
-    ar & boost::serialization::make_nvp("cost_function", cf_name);
-    cost_function = get_cost_function(cf_name);
+      BOOST_SERIALIZATION_NVP(epoch_frequency) &
+      boost::serialization::make_nvp("cost_function", cost_function_name_);
+    // load cost function from name
+    cost_function_ = get_cost_function(cost_function_name_);
   }
 
   // implement serialize()
   BOOST_SERIALIZATION_SPLIT_MEMBER()
 
+public:
 	bool operator==(NeuralNetwork const& nn_) const{
     return nn_.n_layers==n_layers
         && nn_.layers  == layers;
@@ -108,6 +113,32 @@ public:
   }
 
   virtual bool initialize() = 0; // Pure virtual function so this class must be extended.
+
+  /**
+   * Return the cost function name.
+   *
+   * If the name is the empty string then no cost function has been set.
+   */
+  auto& cost_function_name() const noexcept { return cost_function_name_; }
+
+  /**
+   * Return the cost function pointer.
+   *
+   * If the function pointer is `nullptr` then no const function has been set.
+   */
+  auto cost_function() const noexcept { return cost_function_; }
+
+  /**
+   * Set the cost function.
+   *
+   * @param name Cost function name, e.g. `"mse_loss"`, `"huber_loss"`, etc.
+   */
+  auto& cost_function(std::string name)
+  {
+    cost_function_name_ = std::move(name);
+    cost_function_ = get_cost_function(cost_function_name_);
+    return *this;
+  }
 
   /**
    * Set the layer activation function and derivative.
@@ -194,7 +225,7 @@ public:
     std::cout << "expected = " << expected << std::endl;
     std::cout << "layers.back().values() = " << layers.back() << std::endl;
 #endif
-    cnn::real_type mse = cost_function(layers.back().values(), expected.values());
+    cnn::real_type mse = cost_function_(layers.back().values(), expected.values());
     if(epoch_frequency < 100)
       epoch_frequency = 100;
     while(mse > threshold and iter < max_iter){
@@ -298,9 +329,8 @@ public:
         std::cout << "Weights reinitialized" << std::endl;
 #endif
     }
-
 };
 
-};
+}  // namespace cnn
 
-#endif
+#endif  // NN_HPP

--- a/include/nn.hpp
+++ b/include/nn.hpp
@@ -27,9 +27,8 @@
 
 #include "typedef.hpp"
 #include "connector.hpp"
+#include "optimizer.hpp"
 #include "sparse_array.hpp"
-
-#define NVP(a) BOOST_SERIALIZATION_NVP(a)
 
 using namespace boost::numeric::ublas;
 
@@ -37,20 +36,40 @@ namespace cnn{
 
 // A basic neural network base class, it must be extended with customized
 // initialize method
-class NeuralNetwork{
-
+class NeuralNetwork {
 public:
+  //////////////////////////////////////////////////////////////////////////////
+  // serialized members                                                       //
+  //////////////////////////////////////////////////////////////////////////////
   int n_layers;
-	cnn::Layer expected;
-	std::vector< cnn::Layer > layers;
-  cnn::Weights weights;
+	Layer expected;
+	std::vector<Layer> layers;
+  Weights weights;
   int_type epoch_frequency;
-  cnn::CostFunctionPointer cost_function;
+  //////////////////////////////////////////////////////////////////////////////
+  // TODO: need to serialize cost function too
+  inner_product_real_function cost_function;
 
-	template<class Ar>
-	void serialize(Ar& ar, unsigned){
-		ar & NVP(n_layers) & NVP(expected) & NVP(layers) & NVP(weights) & NVP(epoch_frequency);
-	}
+  /**
+   * Boost serialiation function for the neural network base class.
+   *
+   * This serializes all the public members except for the cost function.
+   *
+   * @tparam Ar Boost.Serialization archive type
+   *
+   * @param ar Input/output archive
+   */
+  template <typename Ar>
+  void serialize(Ar& ar, unsigned /*version*/)
+  {
+    ar &
+      BOOST_SERIALIZATION_NVP(n_layers) &
+      BOOST_SERIALIZATION_NVP(expected) &
+      BOOST_SERIALIZATION_NVP(layers) &
+      BOOST_SERIALIZATION_NVP(weights) &
+      BOOST_SERIALIZATION_NVP(epoch_frequency);
+  }
+
 	bool operator==(NeuralNetwork const& nn_) const{
     return nn_.n_layers==n_layers
         && nn_.layers  == layers;
@@ -74,6 +93,16 @@ public:
   }
 
   virtual bool initialize() = 0; // Pure virtual function so this class must be extended.
+
+  /**
+   * Set the layer activation function and derivative.
+   *
+   * @param name Activation function name, e.g. `"relu"`, `"linear"`
+   */
+  void set_optimizer(std::string name)
+  {
+    set_optimizer(optimizer{std::move(name)});
+  }
 
 	void set_optimizer(const optimizer & o){
 #ifdef DEBUG

--- a/include/nn.hpp
+++ b/include/nn.hpp
@@ -2,15 +2,18 @@
 #define NN_HPP
 
 #include <boost/serialization/nvp.hpp>
+#include <boost/serialization/split_member.hpp>
 #include <boost/serialization/vector.hpp>
 
 #include <algorithm>
 #include <cstdio>
 #include <iostream>
+#include <string>
 #include <vector>
 
 #include "typedef.hpp"
 #include "connector.hpp"
+#include "functions.hpp"
 #include "layer.hpp"
 #include "optimizer.hpp"
 #include "sparse_array.hpp"
@@ -28,21 +31,21 @@ public:
 	std::vector<Layer> layers;
   Weights weights;
   int_type epoch_frequency;
-  //////////////////////////////////////////////////////////////////////////////
-  // TODO: need to serialize cost function too
   inner_product_real_function cost_function;
+  //////////////////////////////////////////////////////////////////////////////
 
   /**
-   * Boost serialiation function for the neural network base class.
+   * Boost serialization function.
    *
-   * This serializes all the public members except for the cost function.
+   * This serializes all the public members. The cost function is mapped to a
+   * string name that is written to the archive instead.
    *
-   * @tparam Ar Boost.Serialization archive type
+   * @tparam Ar Boost.Serialization output archive
    *
-   * @param ar Input/output archive
+   * @param ar Output archive
    */
   template <typename Ar>
-  void serialize(Ar& ar, unsigned /*version*/)
+  void save(Ar& ar, unsigned /*version*/) const
   {
     ar &
       BOOST_SERIALIZATION_NVP(n_layers) &
@@ -50,7 +53,37 @@ public:
       BOOST_SERIALIZATION_NVP(layers) &
       BOOST_SERIALIZATION_NVP(weights) &
       BOOST_SERIALIZATION_NVP(epoch_frequency);
+    // save cost function identifier
+    std::string cf_name{get_cost_function_name(cost_function)};
+    ar & boost::serialization::make_nvp("cost_function", cf_name);
   }
+
+  /**
+   * Boost de-serialiation function.
+   *
+   * This retrieves the cost function from the serialized string name.
+   *
+   * @tparam Ar Boost.Serialization input type
+   *
+   * @param ar Input archive
+   */
+  template <typename Ar>
+  void load(Ar& ar, unsigned /*version*/)
+  {
+    ar &
+      BOOST_SERIALIZATION_NVP(n_layers) &
+      BOOST_SERIALIZATION_NVP(expected) &
+      BOOST_SERIALIZATION_NVP(layers) &
+      BOOST_SERIALIZATION_NVP(weights) &
+      BOOST_SERIALIZATION_NVP(epoch_frequency);
+    // load cost function from identifier
+    std::string cf_name;
+    ar & boost::serialization::make_nvp("cost_function", cf_name);
+    cost_function = get_cost_function(cf_name);
+  }
+
+  // implement serialize()
+  BOOST_SERIALIZATION_SPLIT_MEMBER()
 
 	bool operator==(NeuralNetwork const& nn_) const{
     return nn_.n_layers==n_layers

--- a/include/nn.hpp
+++ b/include/nn.hpp
@@ -26,18 +26,16 @@ namespace cnn {
 // initialize method
 class NeuralNetwork {
 public:
-  //////////////////////////////////////////////////////////////////////////////
   // TODO: these members should be private
   int n_layers{};
-	Layer expected;
-	std::vector<Layer> layers;
+  Layer expected;
+  std::vector<Layer> layers;
   Weights weights;
   int_type epoch_frequency{};
 
 private:
   std::string cost_function_name_;               // cost function name
   inner_product_real_function cost_function_{};  // cost function
-  //////////////////////////////////////////////////////////////////////////////
 
   // enable save/load access
   friend class boost::serialization::access;

--- a/include/nn.hpp
+++ b/include/nn.hpp
@@ -1,16 +1,16 @@
 #ifndef NN_HPP
 #define NN_HPP
 
-#include <boost/serialization/access.hpp>
-#include <boost/serialization/nvp.hpp>
-#include <boost/serialization/split_member.hpp>
-#include <boost/serialization/vector.hpp>
-
 #include <algorithm>
 #include <cstdio>
 #include <iostream>
 #include <string>
 #include <vector>
+
+#include <boost/serialization/access.hpp>
+#include <boost/serialization/nvp.hpp>
+#include <boost/serialization/split_member.hpp>
+#include <boost/serialization/vector.hpp>
 
 #include "typedef.hpp"
 #include "connector.hpp"

--- a/include/nn.hpp
+++ b/include/nn.hpp
@@ -131,6 +131,10 @@ public:
   /**
    * Set the cost function.
    *
+   * This function should be called from `initialize()` to set the neural
+   * network's cost function and is the only supported method for setting the
+   * cost function, i.e. do not attempt to set the name + function separately.
+   *
    * @param name Cost function name, e.g. `"mse_loss"`, `"huber_loss"`, etc.
    */
   auto& cost_function(std::string name)

--- a/include/nn.hpp
+++ b/include/nn.hpp
@@ -1,45 +1,27 @@
 #ifndef NN_HPP
 #define NN_HPP
 
-#include "yml_oarchive.hpp"
-#include "yml_iarchive.hpp"
-
+#include <boost/serialization/nvp.hpp>
 #include <boost/serialization/vector.hpp>
-#include <boost/serialization/utility.hpp> // serialize pair
-#include <boost/serialization/array.hpp>
-#include <boost/serialization/set.hpp>
-#include <boost/serialization/optional.hpp> // serialize boost::optional
 
-#include <boost/archive/text_oarchive.hpp>
-#include <boost/archive/text_iarchive.hpp>
-#include <boost/serialization/unordered_map.hpp>
-
-#include <boost/numeric/ublas/matrix.hpp>
-#include <boost/numeric/ublas/io.hpp>
-#include <vector>
-#include <fstream>
-#include <unordered_map>
 #include <algorithm>
-
-#include <stdio.h>
-#include <stdlib.h>
-#include <cassert>
+#include <cstdio>
+#include <iostream>
+#include <vector>
 
 #include "typedef.hpp"
 #include "connector.hpp"
+#include "layer.hpp"
 #include "optimizer.hpp"
 #include "sparse_array.hpp"
+#include "weights.hpp"
 
-using namespace boost::numeric::ublas;
-
-namespace cnn{
+namespace cnn {
 
 // A basic neural network base class, it must be extended with customized
 // initialize method
 class NeuralNetwork {
 public:
-  //////////////////////////////////////////////////////////////////////////////
-  // serialized members                                                       //
   //////////////////////////////////////////////////////////////////////////////
   int n_layers;
 	Layer expected;
@@ -158,7 +140,7 @@ public:
       //delta[j] = 2*(layers[1][j]-expected[j])*sigmoid(layers[1][j])*(1 - sigmoid(layers[1][j]));
       delta[j] = (layers[n_layers-1][j]-expected[j]);
 #ifdef DEBUG
-      printf("l=%d, j=%d: %f %f delta[j]=%f\n", n_layers-1, j, layers[n_layers-1][j], expected[j], delta[j]);
+      std::printf("l=%d, j=%d: %f %f delta[j]=%f\n", n_layers-1, j, layers[n_layers-1][j], expected[j], delta[j]);
 #endif
     }
 

--- a/include/optimizer.hpp
+++ b/include/optimizer.hpp
@@ -1,15 +1,15 @@
 #ifndef OPTIMIZER_HPP
 #define OPTIMIZER_HPP
 
-#include <boost/serialization/access.hpp>
-#include <boost/serialization/nvp.hpp>
-#include <boost/serialization/split_member.hpp>
-#include <boost/serialization/string.hpp>
-
 #include <ostream>
 #include <string>
 #include <tuple>
 #include <utility>
+
+#include <boost/serialization/access.hpp>
+#include <boost/serialization/nvp.hpp>
+#include <boost/serialization/split_member.hpp>
+#include <boost/serialization/string.hpp>
 
 #include "typedef.hpp"
 #include "functions.hpp"
@@ -49,7 +49,7 @@ public:
   /**
    * Invoke the activation function.
    */
-  real_type activate(real_type x) const
+  real_type operator()(real_type x) const
   {
     return act_.f(x);
   }
@@ -57,7 +57,7 @@ public:
   /**
    * Invoke the activation function derivative.
    */
-  real_type derivative(real_type x) const
+  real_type grad(real_type x) const
   {
     return act_.g(x);
   }

--- a/include/optimizer.hpp
+++ b/include/optimizer.hpp
@@ -86,7 +86,7 @@ private:
   template <typename Ar>
   void save(Ar& ar, unsigned /*version*/) const
   {
-    ar & BOOST_SERIALIZATION_NVP(name_);
+    ar & boost::serialization::make_nvp("name", name_);
   }
 
   /**
@@ -101,7 +101,7 @@ private:
   template <typename Ar>
   void load(Ar& ar, unsigned /*version*/)
   {
-    ar & BOOST_SERIALIZATION_NVP(name_);
+    ar & boost::serialization::make_nvp("name", name_);
     act_ = get_activation(name_);
   }
 

--- a/include/optimizer.hpp
+++ b/include/optimizer.hpp
@@ -2,6 +2,7 @@
 #define OPTIMIZER_HPP
 
 #include <boost/serialization/nvp.hpp>
+#include <boost/serialization/split_member.hpp>
 #include <boost/serialization/string.hpp>
 
 #include <ostream>
@@ -22,12 +23,35 @@ public:
   unary_real_function activate;
   unary_real_function derivative_funcptr;
 
-  // TODO: split into save/load where load uses to_activation()
-  template<class Ar>
-  void serialize(Ar& ar, unsigned /*version*/)
+  /**
+   * Boost serialization function.
+   *
+   * This saves just the name of the `optimizer` object.
+   *
+   * @tparam Ar Boost.Serialization output archive
+   */
+  template <typename Ar>
+  void save(Ar& ar, unsigned /*version*/) const
   {
     ar & BOOST_SERIALIZATION_NVP(name);
   }
+
+  /**
+   * Boost de-serialization function.
+   *
+   * This loads the `optimizer` name and then uses it set the activation.
+   *
+   * @tparam Ar Boost.Serialization input archive
+   */
+  template <typename Ar>
+  void load(Ar& ar, unsigned /*version*/)
+  {
+    ar & BOOST_SERIALIZATION_NVP(name);
+    std::tie(activate, derivative_funcptr) = get_activation(name).pair();
+  }
+
+  // implement serialize()
+  BOOST_SERIALIZATION_SPLIT_MEMBER()
 
   /**
    * Default ctor.

--- a/include/optimizer.hpp
+++ b/include/optimizer.hpp
@@ -1,6 +1,7 @@
 #ifndef OPTIMIZER_HPP
 #define OPTIMIZER_HPP
 
+#include <boost/serialization/access.hpp>
 #include <boost/serialization/nvp.hpp>
 #include <boost/serialization/split_member.hpp>
 #include <boost/serialization/string.hpp>
@@ -15,13 +16,63 @@
 
 namespace cnn {
 
-/* Provide function pointers to activation function and derivative of activation function */
+/**
+ * Layer optimizer class.
+ *
+ * This holds function pointers to the activation function and its derivative.
+ */
 class optimizer {
 public:
-  std::string name;
-  // TODO: replace with activation as single member
-  unary_real_function activate;
-  unary_real_function derivative_funcptr;
+  /**
+   * Default ctor.
+   *
+   * This initializes the `"linear"` activation function.
+   */
+  optimizer() : name_{"linear"}, act_{linear, derivative_linear} {}
+
+  /**
+   * Ctor.
+   *
+   * Construct from a valid activation function identifier.
+   *
+   * @param name Activation function, e.g. `"relu"`, `"linear"`, etc.
+   */
+  optimizer(std::string name)
+    : name_{std::move(name)}, act_{get_activation(name_)}
+  {}
+
+  /**
+   * Return the name of the layer activation.
+   */
+  auto& name() const noexcept { return name_; }
+
+  /**
+   * Invoke the activation function.
+   */
+  real_type activate(real_type x) const
+  {
+    return act_.f(x);
+  }
+
+  /**
+   * Invoke the activation function derivative.
+   */
+  real_type derivative(real_type x) const
+  {
+    return act_.g(x);
+  }
+
+  friend std::ostream& operator<<(std::ostream& out, const optimizer& opt)
+  {
+    return out << "optimizer = " << opt.name();
+  }
+
+private:
+  std::string name_;  // activation name
+  activation act_;    // activation function + derivative pointers
+
+  // enable save/load access
+  friend class boost::serialization::access;
 
   /**
    * Boost serialization function.
@@ -35,7 +86,7 @@ public:
   template <typename Ar>
   void save(Ar& ar, unsigned /*version*/) const
   {
-    ar & BOOST_SERIALIZATION_NVP(name);
+    ar & BOOST_SERIALIZATION_NVP(name_);
   }
 
   /**
@@ -50,40 +101,12 @@ public:
   template <typename Ar>
   void load(Ar& ar, unsigned /*version*/)
   {
-    ar & BOOST_SERIALIZATION_NVP(name);
-    std::tie(activate, derivative_funcptr) = get_activation(name).pair();
+    ar & BOOST_SERIALIZATION_NVP(name_);
+    act_ = get_activation(name_);
   }
 
   // implement serialize()
   BOOST_SERIALIZATION_SPLIT_MEMBER()
-
-  /**
-   * Default ctor.
-   *
-   * This initializes the `"linear"` activation function.
-   */
-  optimizer()
-    : name{"linear"}, activate{linear}, derivative_funcptr{derivative_linear}
-  {}
-
-  // construct from name
-  /**
-   * Ctor.
-   *
-   * Construct from a valid activation function identifier.
-   *
-   * @param name Activation function, e.g. `"relu"`, `"linear"`, etc.
-   */
-  optimizer(std::string name) : name{std::move(name)}
-  {
-    // FIXME: name shadowing is tricky
-    std::tie(activate, derivative_funcptr) = get_activation(this->name).pair();
-  }
-
-  friend std::ostream& operator<<(std::ostream& out, const optimizer& o)
-  {
-    return out << "optimizer = " << o.name;
-  }
 };
 
 }  // namespace cnn

--- a/include/optimizer.hpp
+++ b/include/optimizer.hpp
@@ -29,6 +29,8 @@ public:
    * This saves just the name of the `optimizer` object.
    *
    * @tparam Ar Boost.Serialization output archive
+   *
+   * @param ar Output archive
    */
   template <typename Ar>
   void save(Ar& ar, unsigned /*version*/) const
@@ -42,6 +44,8 @@ public:
    * This loads the `optimizer` name and then uses it set the activation.
    *
    * @tparam Ar Boost.Serialization input archive
+   *
+   * @param ar Input archive
    */
   template <typename Ar>
   void load(Ar& ar, unsigned /*version*/)

--- a/include/optimizer.hpp
+++ b/include/optimizer.hpp
@@ -1,48 +1,63 @@
 #ifndef OPTIMIZER_HPP
 #define OPTIMIZER_HPP
 
-#include "yml_oarchive.hpp"
-#include "yml_iarchive.hpp"
+#include <boost/serialization/nvp.hpp>
+#include <boost/serialization/string.hpp>
 
-#include <boost/serialization/vector.hpp>
-#include <boost/serialization/utility.hpp> // serialize pair
-#include <boost/serialization/array.hpp>
-#include <boost/serialization/set.hpp>
-#include <boost/serialization/optional.hpp> // serialize boost::optional
-
-#define NVP(a) BOOST_SERIALIZATION_NVP(a)
-
+#include <ostream>
 #include <string>
+#include <tuple>
+#include <utility>
+
 #include "typedef.hpp"
 #include "functions.hpp"
 
-namespace cnn{
+namespace cnn {
 
-	/* Provide function pointers to activatation function and derivative of activation function */
-	class optimizer{
-		public:
-      typedef cnn::real_type (*FunctionPointer)(cnn::real_type);
+/* Provide function pointers to activation function and derivative of activation function */
+class optimizer {
+public:
+  std::string name;
+  // TODO: replace with activation as single member
+  unary_real_function activate;
+  unary_real_function derivative_funcptr;
 
-      std::string name;
-	    FunctionPointer activate;
-	    FunctionPointer derivative_funcptr;
+  // TODO: split into save/load where load uses to_activation()
+  template<class Ar>
+  void serialize(Ar& ar, unsigned /*version*/)
+  {
+    ar & BOOST_SERIALIZATION_NVP(name);
+  }
 
-		template<class Ar>
-		void serialize(Ar& ar, unsigned){
-			ar & NVP(name);
-		}
+  /**
+   * Default ctor.
+   *
+   * This initializes the `"linear"` activation function.
+   */
+  optimizer()
+    : name{"linear"}, activate{linear}, derivative_funcptr{derivative_linear}
+  {}
 
-		// Default constructor using linear function
-		optimizer(): name ("linear"), activate(linear), derivative_funcptr(derivative_linear) {}
-		// Initialize with a new optimizer
-		optimizer(std::string name, cnn::real_type (*funcptr) (cnn::real_type), cnn::real_type (*derivative_funcptr) (cnn::real_type) ): name (name), activate(funcptr), derivative_funcptr(derivative_funcptr){
-		}
-		optimizer(const optimizer & o): name (o.name), activate(o.activate), derivative_funcptr(o.derivative_funcptr) {}
-		friend std::ostream& operator<< (std::ostream& stream, const optimizer & o) {
-			std::cout << "optimizer = " << o.name << std::endl;
-			return stream;
-		}
-	};
-}
+  // construct from name
+  /**
+   * Ctor.
+   *
+   * Construct from a valid activation function identifier.
+   *
+   * @param name Activation function, e.g. `"relu"`, `"linear"`, etc.
+   */
+  optimizer(std::string name) : name{std::move(name)}
+  {
+    // FIXME: name shadowing is tricky
+    std::tie(activate, derivative_funcptr) = get_activation(this->name).pair();
+  }
 
-#endif
+  friend std::ostream& operator<<(std::ostream& out, const optimizer& o)
+  {
+    return out << "optimizer = " << o.name;
+  }
+};
+
+}  // namespace cnn
+
+#endif  // OPTIMIZER_HPP

--- a/include/typedef.hpp
+++ b/include/typedef.hpp
@@ -1,12 +1,22 @@
 #ifndef TYPEDEF_HPP
 #define TYPEDEF_HPP
 
-#define NVP(a) BOOST_SERIALIZATION_NVP(a) 
-namespace cnn{
+// TODO: remove
+#define NVP(a) BOOST_SERIALIZATION_NVP(a)
 
-  typedef unsigned int int_type;
-  typedef float real_type;
+#include <vector>
 
-};
+namespace cnn {
 
-#endif
+typedef unsigned int int_type;
+typedef float real_type;
+
+// univariate real_type function
+using unary_real_function = real_type(*)(real_type);
+// vector + vector to scalar real_type function
+using inner_product_real_function =
+  real_type(*)(const std::vector<real_type>&, const std::vector<real_type>&);
+
+}  // namespace cnn
+
+#endif  // TYPEDEF_HPP

--- a/include/typedef.hpp
+++ b/include/typedef.hpp
@@ -1,9 +1,6 @@
 #ifndef TYPEDEF_HPP
 #define TYPEDEF_HPP
 
-// TODO: remove
-#define NVP(a) BOOST_SERIALIZATION_NVP(a)
-
 #include <vector>
 
 namespace cnn {

--- a/include/weights.hpp
+++ b/include/weights.hpp
@@ -1,45 +1,27 @@
 #ifndef WEIGHTS_HPP
 #define WEIGHTS_HPP
 
-#include "yml_oarchive.hpp"
-#include "yml_iarchive.hpp"
-
-#include <boost/serialization/vector.hpp>
-#include <boost/serialization/utility.hpp> // serialize pair
-#include <boost/serialization/array.hpp>
-#include <boost/serialization/set.hpp>
-#include <boost/serialization/optional.hpp> // serialize boost::optional
-
-#include <boost/archive/text_oarchive.hpp>
-#include <boost/archive/text_iarchive.hpp>
-#include <boost/serialization/unordered_map.hpp>
-
-#include <boost/numeric/ublas/matrix.hpp>
-#include <boost/numeric/ublas/io.hpp>
-#include <vector>
+#include <algorithm>
+#include <cmath>
 #include <fstream>
-#include <unordered_map>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <numeric>
+#include <vector>
 
-#include <stdio.h> 
-#include <stdlib.h> 
-#include <cassert>
+#include <boost/archive/text_iarchive.hpp>
+#include <boost/archive/text_oarchive.hpp>
+#include <boost/serialization/access.hpp>
+#include <boost/serialization/nvp.hpp>
+#include <boost/serialization/unordered_map.hpp>
+#include <boost/serialization/vector.hpp>
 
 #include "typedef.hpp"
 #include "connector.hpp"
 #include "sparse_array.hpp"
 
-#include <iostream>
-#include <iomanip>
-#include <algorithm>
-#include <vector>
-#include <numeric>
-#include <cmath>
-#include <limits>
-#define NVP(a) BOOST_SERIALIZATION_NVP(a)
-
-using namespace boost::numeric::ublas;
-
-namespace cnn{
+namespace cnn {
 
 struct WeightStats {
     double mean;
@@ -50,20 +32,21 @@ struct WeightStats {
     size_t count;
 };
 
-class Weights{
+class Weights {
+public:
+  // TODO: can be private if Weights has operator[] and iterator support
+  sparse_array<Connector> w;
+
+private:
+  friend class boost::serialization::access;
+
+	template <typename Ar>
+	void serialize(Ar& ar, unsigned /*version*/)
+  {
+    ar & BOOST_SERIALIZATION_NVP(w);
+	}
 
 public:
-  sparse_array<cnn::Connector> w;
-
-	template<class Ar>
-	void serialize(Ar& ar, unsigned){
-    //for (const auto& [key, value] : w){
-		//	for (int n : key)
-    //    ar & NVP( n);
-    //  ar & NVP( value );
-    //}
-    ar & NVP(w);
-	}
 	bool operator==(Weights const& w_) const{return w_.w.size() == w.size();}
 
 	void save(const std::string& filename) {
@@ -90,7 +73,7 @@ public:
   }
 
   WeightStats calculate_weight_statistics() const {
-    WeightStats stats{0.0, 0.0, 0.0, std::numeric_limits<double>::max(), 
+    WeightStats stats{0.0, 0.0, 0.0, std::numeric_limits<double>::max(),
                      -std::numeric_limits<double>::max(), 0};
     std::vector<double> all_weights;
     all_weights.reserve(w.size());
@@ -131,7 +114,7 @@ public:
         sum_squared_diff += diff * diff;
     }
     stats.stddev = std::sqrt(sum_squared_diff / n);
-    
+
     stats.count = n;
 
     return stats;
@@ -148,10 +131,8 @@ public:
               << "  Median: " << std::fixed << std::setprecision(6) << stats.median << "\n"
               << "  StdDev: " << std::fixed << std::setprecision(6) << stats.stddev << "\n";
   }
-
-private:
 };
 
-};
+}  // namespace cnn
 
-#endif
+#endif  // WEIGHTS_HPP

--- a/include/weights.hpp
+++ b/include/weights.hpp
@@ -40,11 +40,11 @@ public:
 private:
   friend class boost::serialization::access;
 
-	template <typename Ar>
-	void serialize(Ar& ar, unsigned /*version*/)
+  template <typename Ar>
+  void serialize(Ar& ar, unsigned /*version*/)
   {
     ar & BOOST_SERIALIZATION_NVP(w);
-	}
+  }
 
 public:
 	bool operator==(Weights const& w_) const{return w_.w.size() == w.size();}

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -356,4 +356,21 @@ inner_product_real_function get_cost_function(std::string_view name)
     return map.at(name);
 }
 
+std::string_view get_cost_function_name(inner_product_real_function func)
+{
+#define EXCCNN_COST_NAME_MAP_ENTRY(name) {name, #name}
+    static std::map<inner_product_real_function, std::string_view> map{
+        EXCCNN_COST_NAME_MAP_ENTRY(cross_entropy_loss),
+        EXCCNN_COST_NAME_MAP_ENTRY(mse_loss),
+        EXCCNN_COST_NAME_MAP_ENTRY(mae_loss),
+        // note: special treatement for huber_loss due to default arguments
+        {huber_loss_, "huber_loss"},
+        EXCCNN_COST_NAME_MAP_ENTRY(binary_cross_entropy_loss),
+        EXCCNN_COST_NAME_MAP_ENTRY(hinge_loss),
+        EXCCNN_COST_NAME_MAP_ENTRY(kl_divergence_loss)
+    };
+#undef EXCCNN_COST_NAME_MAP_ENTRY
+    return map.at(func);
+}
+
 }  // namespace cnn

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -13,28 +13,34 @@
 
 namespace cnn {
 
-real_type linear(const real_type x){
+real_type linear(const real_type x)
+{
 	return x;
 }
 
-real_type derivative_linear(const real_type x){
+real_type derivative_linear(const real_type /*x*/)
+{
 	return 1;
 }
 
-real_type sigmoid(const real_type x){
-	return 1./(1. + exp(-x));
+real_type sigmoid(const real_type x)
+{
+	return 1 / (1 + std::exp(-x));
 }
 
-real_type derivative_sigmoid(const real_type x){
-	return sigmoid(x)*(1. - sigmoid(x));
+real_type derivative_sigmoid(const real_type x)
+{
+	return sigmoid(x) * (real_type{1} - sigmoid(x));
 }
 
-real_type relu(const real_type x) {
-	return std::max(static_cast<real_type>(0.0), x);
+real_type relu(const real_type x)
+{
+	return std::max(real_type{}, x);
 }
 
-real_type derivative_relu(const real_type x) {
-	return x > 0.0 ? 1.0 : 0.0;
+real_type derivative_relu(const real_type x)
+{
+	return x > real_type{} ? real_type{1} : real_type{};
 }
 
 activation get_activation(std::string_view name)

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -356,21 +356,4 @@ inner_product_real_function get_cost_function(std::string_view name)
     return map.at(name);
 }
 
-std::string_view get_cost_function_name(inner_product_real_function func)
-{
-#define EXCCNN_COST_NAME_MAP_ENTRY(name) {name, #name}
-    static std::map<inner_product_real_function, std::string_view> map{
-        EXCCNN_COST_NAME_MAP_ENTRY(cross_entropy_loss),
-        EXCCNN_COST_NAME_MAP_ENTRY(mse_loss),
-        EXCCNN_COST_NAME_MAP_ENTRY(mae_loss),
-        // note: special treatement for huber_loss due to default arguments
-        {huber_loss_, "huber_loss"},
-        EXCCNN_COST_NAME_MAP_ENTRY(binary_cross_entropy_loss),
-        EXCCNN_COST_NAME_MAP_ENTRY(hinge_loss),
-        EXCCNN_COST_NAME_MAP_ENTRY(kl_divergence_loss)
-    };
-#undef EXCCNN_COST_NAME_MAP_ENTRY
-    return map.at(func);
-}
-
 }  // namespace cnn

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -1,37 +1,53 @@
 #include "functions.hpp"
 
-#include <cmath>
 #include <algorithm>
-#include <numeric>
-#include <stdexcept>
+#include <cmath>
 #include <iostream>
 #include <limits>
+#include <map>
+#include <numeric>
 #include <random>
+#include <stdexcept>
+#include <string_view>
+#include <vector>
 
 namespace cnn {
 
-cnn::real_type linear(const cnn::real_type x){
+real_type linear(const real_type x){
 	return x;
 }
 
-cnn::real_type derivative_linear(const cnn::real_type x){
+real_type derivative_linear(const real_type x){
 	return 1;
 }
 
-cnn::real_type sigmoid(const cnn::real_type x){
+real_type sigmoid(const real_type x){
 	return 1./(1. + exp(-x));
 }
 
-cnn::real_type derivative_sigmoid(const cnn::real_type x){
+real_type derivative_sigmoid(const real_type x){
 	return sigmoid(x)*(1. - sigmoid(x));
 }
 
-cnn::real_type relu(const cnn::real_type x) {
+real_type relu(const real_type x) {
 	return std::max(static_cast<real_type>(0.0), x);
 }
 
-cnn::real_type derivative_relu(const cnn::real_type x) {
+real_type derivative_relu(const real_type x) {
 	return x > 0.0 ? 1.0 : 0.0;
+}
+
+activation get_activation(std::string_view name)
+{
+#define EXCCNN_ACTIVATION_MAP_ENTRY(name) {#name, {name, derivative_ ## name}}
+    static std::map<std::string_view, activation> map{
+        EXCCNN_ACTIVATION_MAP_ENTRY(linear),
+        EXCCNN_ACTIVATION_MAP_ENTRY(sigmoid),
+        EXCCNN_ACTIVATION_MAP_ENTRY(relu),
+        EXCCNN_ACTIVATION_MAP_ENTRY(softmax)
+    };
+#undef EXCCNN_ACTIVATION_MAP_ENTRY
+    return map.at(name);
 }
 
 cnn::real_type cross_entropy_loss(const std::vector<cnn::real_type>& predicted,
@@ -303,6 +319,35 @@ std::vector<std::vector<real_type>> orthogonal_init(int rows, int cols) {
     }
 
     return Q;
+}
+
+namespace {
+
+// huber loss with defaulted delta due to fixed function pointer type
+real_type huber_loss_(
+    const std::vector<real_type>& predicted,
+    const std::vector<real_type>& target)
+{
+    return huber_loss(predicted, target);
+}
+
+}  // namespace
+
+inner_product_real_function get_cost_function(std::string_view name)
+{
+#define EXCCNN_COST_MAP_ENTRY(name) {#name, name}
+    static std::map<std::string_view, inner_product_real_function> map{
+        EXCCNN_COST_MAP_ENTRY(cross_entropy_loss),
+        EXCCNN_COST_MAP_ENTRY(mse_loss),
+        EXCCNN_COST_MAP_ENTRY(mae_loss),
+        // note: special treatment for huber_loss due to default arguments
+        {"huber_loss", huber_loss_},
+        EXCCNN_COST_MAP_ENTRY(binary_cross_entropy_loss),
+        EXCCNN_COST_MAP_ENTRY(hinge_loss),
+        EXCCNN_COST_MAP_ENTRY(kl_divergence_loss)
+    };
+#undef EXCCNN_COST_MAP_ENTRY
+    return map.at(name);
 }
 
 }  // namespace cnn

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -193,11 +193,9 @@ exccnn_add_test(test_map_archive LIBRARIES Boost::headers Boost::serialization)
 exccnn_add_test(test_matrix LIBRARIES Boost::headers cnnlib)
 
 # test_neuron: test CNN neuron class
-# FIXME: test just includes neuron.hpp and returns zero
 exccnn_add_test(test_neuron LIBRARIES cnnlib)
 
 # test_optimizer: test CNN optimizer class
-# note: mostly a smoke test of construction and doesn't do much
 exccnn_add_test(test_optimizer LIBRARIES cnnlib)
 
 # test_rand: test the stdlib.h rand() function

--- a/test/test_cnn2.cpp
+++ b/test/test_cnn2.cpp
@@ -1,30 +1,16 @@
 // Test program to read a yaml file and generate a neural network accordingly
 
 #include "yml_oarchive.hpp"
-#include "yml_iarchive.hpp"
 
-#include <boost/serialization/vector.hpp>
-#include <boost/serialization/utility.hpp> // serialize pair
-#include <boost/serialization/array.hpp>
-#include <boost/serialization/set.hpp>
-#include <boost/serialization/optional.hpp> // serialize boost::optional
-
+#include <cstdlib>
 #include <fstream>
 #include <iostream>
-#include <string>
-#include <vector>
-#include <cmath>
 
-#include "typedef.hpp"
-#include "connection.hpp"
+#include "connector.hpp"
 #include "functions.hpp"
-#include "neuron.hpp"
 #include "layer.hpp"
-#include "utils.hpp"
-#include "weights.hpp"
 #include "nn.hpp"
-
-#define NVP(a) BOOST_SERIALIZATION_NVP(a)
+#include "sparse_array.hpp"
 
 class simple_neural_network : public cnn::NeuralNetwork {
 
@@ -62,7 +48,7 @@ bool simple_neural_network::initialize() {
 	}
 
   // MSE loss
-  cost_function = cnn::mse_loss;
+  cost_function("mse_loss");
 
   std::cout << "input: " << layers[0];
   std::cout << "output: " << layers[1];
@@ -72,18 +58,15 @@ bool simple_neural_network::initialize() {
 
 }
 
-int main(){
-
+int main()
+{
 	simple_neural_network nn;
 	nn.initialize();
   nn.update();
-
 	{
 		std::ofstream ofs{"trained2.yml"};
 		boost::archive::yml_oarchive yoa{ofs};
-		yoa
-			<< NVP(nn)
-		;
+		yoa << BOOST_SERIALIZATION_NVP(nn);
 	}
-
+  return EXIT_SUCCESS;
 }

--- a/test/test_cnn2_import.cpp
+++ b/test/test_cnn2_import.cpp
@@ -3,37 +3,24 @@
 #include "yml_oarchive.hpp"
 #include "yml_iarchive.hpp"
 
-#include <boost/serialization/vector.hpp>
-#include <boost/serialization/utility.hpp> // serialize pair
-#include <boost/serialization/array.hpp>
-#include <boost/serialization/set.hpp>
-#include <boost/serialization/optional.hpp> // serialize boost::optional
+#include <boost/serialization/nvp.hpp>
 
+#include <cstdlib>
 #include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 #include <cmath>
 
-#include "typedef.hpp"
-#include "connection.hpp"
-#include "functions.hpp"
-#include "neuron.hpp"
-#include "layer.hpp"
-#include "utils.hpp"
-#include "weights.hpp"
 #include "nn.hpp"
 
-#define NVP(a) BOOST_SERIALIZATION_NVP(a) 
-
 class simple_neural_network : public cnn::NeuralNetwork {
-
 public:
   bool initialize() override;
 };
 
-bool simple_neural_network::initialize() {
-
+bool simple_neural_network::initialize()
+{
 	//n_layers = 2;
 
 	//cnn::Layer input_layer = cnn::Layer(4); // make a input layer of 4 neurons.
@@ -52,45 +39,31 @@ bool simple_neural_network::initialize() {
   //expected[1] = 0.;
   //expected[2] = 0.;
   //expected[3] = 0.;
-
-  // MSE loss
-  // FIXME: nn, optimizer, etc. serialization, e.g. anything involving function
-  // pointers, is lossy. so we need to set function pointers manually to ensure
-  // "de-serialized" models don't crash if they aren't default initialized. in
-  // this case we know test_cnn2.cpp is already using mse_loss and defaulted
-  // optimizer objects, but in general this is not a root cause fix.
-  cost_function = cnn::mse_loss;
-
-  // should have been reconstituted already
-  std::cout << "input: " << layers[0];
-  std::cout << "output: " << layers[1];
-  std::cout << "weights: " << weights;
-
 	return true;
-
 }
 
-int main() {
-
+int main()
+{
+  // populate from YAML archive
 	simple_neural_network nn;
 	{
 		std::ifstream ifs{"trained2.yml"};
 		boost::archive::yml_iarchive yia{ifs};
-		yia
-			>> NVP(nn)
-		;
+		yia >> BOOST_SERIALIZATION_NVP(nn);
 	}
-  // see initialize() FIXME above
-  nn.initialize();
+  // print input, output, weights
+  std::cout <<
+    "input: " << nn.layers[0] <<
+    "output: " << nn.layers[1] <<
+    "weights: " << nn.weights << std::flush;
+  // update + print weights again
   nn.update();
   std::cout << "weights: " << nn.weights;
-
+  // write back to YAML archive
 	{
 		std::ofstream ofs{"trained2.yml"};
 		boost::archive::yml_oarchive yoa{ofs};
-		yoa
-			<< NVP(nn)
-		;
+		yoa << BOOST_SERIALIZATION_NVP(nn);
 	}
-
+  return EXIT_SUCCESS;
 }

--- a/test/test_cnn3.cpp
+++ b/test/test_cnn3.cpp
@@ -63,7 +63,7 @@ bool simple_neural_network::initialize(){
   }
 
   // MSE loss
-  cost_function = cnn::mse_loss;
+  cost_function("mse_loss");
 
   std::cout << "input: " << layers[0];
   std::cout << "output: " << layers[1];

--- a/test/test_cnn3.cpp
+++ b/test/test_cnn3.cpp
@@ -1,37 +1,24 @@
-#include <yml_oarchive.hpp>
-#include <yml_iarchive.hpp>
-
-#include <boost/serialization/vector.hpp>
-#include <boost/serialization/utility.hpp>
-#include <boost/serialization/array.hpp>
-#include <boost/serialization/set.hpp>
-#include <boost/serialization/optional.hpp>
-
+#include <cstdlib>
 #include <fstream>
 #include <iostream>
-#include <string>
-#include <vector>
-#include <cmath>
+
+#include <boost/serialization/nvp.hpp>
+#include "yml_oarchive.hpp"
 
 #include "typedef.hpp"
-#include "connection.hpp"
+#include "connector.hpp"
 #include "functions.hpp"
-#include "neuron.hpp"
 #include "layer.hpp"
-#include "utils.hpp"
-#include "weights.hpp"
 #include "nn.hpp"
+#include "sparse_array.hpp"
 
-#define NVP(a) BOOST_SERIALIZATION_NVP(a)
-
-class simple_neural_network : public cnn::NeuralNetwork{
-
+class simple_neural_network : public cnn::NeuralNetwork {
 public:
   bool initialize() override;
-
 };
 
-bool simple_neural_network::initialize(){
+bool simple_neural_network::initialize()
+{
   n_layers = 2;
 
   cnn::Layer input_layer = cnn::Layer(5);
@@ -72,18 +59,15 @@ bool simple_neural_network::initialize(){
 
 }
 
-int main() {
-
+int main()
+{
   simple_neural_network nn;
   nn.initialize();
   nn.update();
-
   {
     std::ofstream ofs{"trained3.yml"};
     boost::archive::yml_oarchive yoa{ofs};
-    yoa
-      << NVP(nn)
-    ;
+    yoa << BOOST_SERIALIZATION_NVP(nn);
   }
-
+  return EXIT_SUCCESS;
 }

--- a/test/test_cnn4.cpp
+++ b/test/test_cnn4.cpp
@@ -80,7 +80,7 @@ bool simple_neural_network::initialize() {
   }
 
   // MSE loss
-  cost_function = cnn::mse_loss;
+  cost_function("mse_loss");
 
   std::cout << "input: " << layers[0];
   std::cout << "output: " << layers[1];

--- a/test/test_cnn4.cpp
+++ b/test/test_cnn4.cpp
@@ -1,33 +1,19 @@
 // Test program to read a yaml file and generate a neural network accordingly
 
-#include "yml_oarchive.hpp"
-#include "yml_iarchive.hpp"
-
-#include <boost/serialization/vector.hpp>
-#include <boost/serialization/utility.hpp> // serialize pair
-#include <boost/serialization/array.hpp>
-#include <boost/serialization/set.hpp>
-#include <boost/serialization/optional.hpp> // serialize boost::optional
-
+#include <cstdlib>
 #include <fstream>
 #include <iostream>
-#include <string>
-#include <vector>
-#include <cmath>
+
+#include <boost/serialization/nvp.hpp>
+#include "yml_oarchive.hpp"
 
 #include "typedef.hpp"
-#include "connection.hpp"
+#include "connector.hpp"
 #include "functions.hpp"
-#include "neuron.hpp"
 #include "layer.hpp"
-#include "utils.hpp"
-#include "weights.hpp"
 #include "nn.hpp"
 
-#define NVP(a) BOOST_SERIALIZATION_NVP(a)
-
 class simple_neural_network : public cnn::NeuralNetwork {
-
 public:
   bool initialize() override;
 };
@@ -90,19 +76,16 @@ bool simple_neural_network::initialize() {
 
 }
 
-int main(){
-
+int main()
+{
   simple_neural_network nn;
   nn.initialize();
   nn.update();
   std::cout << nn.cost() << std::endl;
-
   {
     std::ofstream ofs{"trained4.yml"};
     boost::archive::yml_oarchive yoa{ofs};
-    yoa
-      << NVP(nn)
-    ;
+    yoa << BOOST_SERIALIZATION_NVP(nn);
   }
-
+  return EXIT_SUCCESS;
 }

--- a/test/test_cnn5.cpp
+++ b/test/test_cnn5.cpp
@@ -1,36 +1,22 @@
 // Test program to read a yaml file and generate a neural network accordingly
 
-#include "yml_oarchive.hpp"
-#include "yml_iarchive.hpp"
-
-#include <boost/serialization/vector.hpp>
-#include <boost/serialization/utility.hpp> // serialize pair
-#include <boost/serialization/array.hpp>
-#include <boost/serialization/set.hpp>
-#include <boost/serialization/optional.hpp> // serialize boost::optional
-
+#include <cstdlib>
+#include <exception>
 #include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
-#include <cmath>
+
+#include <boost/serialization/nvp.hpp>
+#include "yml_oarchive.hpp"
 
 #include "typedef.hpp"
-#include "connection.hpp"
-#include "functions.hpp"
-#include "neuron.hpp"
+#include "connector.hpp"
 #include "layer.hpp"
-#include "utils.hpp"
-#include "weights.hpp"
-#include "nn.hpp"
 #include "mnist.hpp"
-#include "functions.hpp"
-#include "optimizer.hpp"
-
-#define NVP(a) BOOST_SERIALIZATION_NVP(a)
+#include "nn.hpp"
 
 class simple_neural_network : public cnn::NeuralNetwork {
-
 public:
   bool initialize() override;
   bool reset_input(const std::vector<std::vector<cnn::real_type>> & input, const int index);
@@ -101,7 +87,8 @@ simple_neural_network::reset_expected(const int & index){
 	return true;
 }
 
-int main(){
+int main()
+{
 	// image and label gzip file names
 	std::string imageFileName = "test/testinput/t10k-images-idx3-ubyte.gz";
 	std::string labelFileName = "test/testinput/t10k-labels-idx1-ubyte.gz";
@@ -145,9 +132,8 @@ int main(){
   {
     std::ofstream ofs{"trained5.yml"};
     boost::archive::yml_oarchive yoa{ofs};
-    yoa
-      << NVP(nn)
-    ;
+    yoa << BOOST_SERIALIZATION_NVP(nn);
   }
 
+  return EXIT_SUCCESS;
 }

--- a/test/test_cnn5.cpp
+++ b/test/test_cnn5.cpp
@@ -71,7 +71,7 @@ bool simple_neural_network::initialize() {
   }
 
   // cross-entropy classifier loss
-  cost_function = cnn::cross_entropy_loss;
+  cost_function("cross_entropy_loss");
 
   // note: commented out since this gets very verbose
   // std::cout << "input: " << layers[0];

--- a/test/test_cnn5.cpp
+++ b/test/test_cnn5.cpp
@@ -133,7 +133,7 @@ int main(){
 
 	// Train the neural network with the 1000 images as training set
 	nn.initialize();
-	nn.set_optimizer(cnn::optimizer("sigmoid", cnn::sigmoid, cnn::derivative_sigmoid));
+  nn.set_optimizer("sigmoid");
   for (int i = 0; i < 1000; i ++){
 		std::cout << "processing mnist training set #" << i << std::endl;
     nn.reset_input(pixelValues, i);

--- a/test/test_cnn6.cpp
+++ b/test/test_cnn6.cpp
@@ -76,9 +76,9 @@ bool simple_neural_network::initialize() {
     }
 
     cost_function = cnn::cross_entropy_loss;
-    layers[0].set_optimizer(cnn::optimizer("relu", cnn::relu, cnn::derivative_relu));
-    layers[1].set_optimizer(cnn::optimizer("relu", cnn::relu, cnn::derivative_relu));
-    //layers.back().set_optimizer(cnn::optimizer("softmax", cnn::softmax, cnn::derivative_softmax));
+    layers[0].set_optimizer("relu");
+    layers[1].set_optimizer("relu");
+    //layers.back().set_optimizer("softmax");
 
     return true;
 }

--- a/test/test_cnn6.cpp
+++ b/test/test_cnn6.cpp
@@ -1,38 +1,27 @@
 // Test program to read a yaml file and generate a neural network accordingly
 
-#include "yml_oarchive.hpp"
-#include "yml_iarchive.hpp"
-
-#include <boost/serialization/vector.hpp>
-#include <boost/serialization/utility.hpp> // serialize pair
-#include <boost/serialization/array.hpp>
-#include <boost/serialization/set.hpp>
-#include <boost/serialization/optional.hpp> // serialize boost::optional
-
 #include <fstream>
-#include <iostream>
-#include <string>
-#include <vector>
-#include <cmath>
 #include <iomanip>
+#include <iostream>
 #include <numeric>
 #include <random>
+#include <string>
+#include <vector>
+
+#include <boost/serialization/nvp.hpp>
+#include "yml_iarchive.hpp"
+#include "yml_oarchive.hpp"
 
 #include "typedef.hpp"
-#include "connection.hpp"
-#include "neuron.hpp"
+#include "connector.hpp"
 #include "layer.hpp"
-#include "utils.hpp"
-#include "weights.hpp"
-#include "nn.hpp"
 #include "mnist.hpp"
-#include "functions.hpp"
-#include "optimizer.hpp"
+#include "nn.hpp"
 
+// convenience macro
 #define NVP(a) BOOST_SERIALIZATION_NVP(a)
 
-class simple_neural_network : public cnn::NeuralNetwork{
-
+class simple_neural_network : public cnn::NeuralNetwork {
 public:
   bool initialize();
   bool reset_input(const std::vector<std::vector<cnn::real_type>> & input, const int index);
@@ -200,8 +189,8 @@ int main(int argc, char* argv[]) {
             boost::archive::yml_iarchive yia{ifs};
             yia >> NVP(nn);
         }
-        //nn.set_optimizer(cnn::optimizer("sigmoid", cnn::sigmoid, cnn::derivative_sigmoid));
-        //nn.set_optimizer(cnn::optimizer("relu", cnn::relu, cnn::derivative_relu));
+        //nn.set_optimizer("sigmoid");
+        //nn.set_optimizer("relu");
 
         for(cnn::int_type idx = 0; idx < pixelValues.size(); idx++){
             std::cout << "Processing image #" << idx << std::endl;

--- a/test/test_cnn6.cpp
+++ b/test/test_cnn6.cpp
@@ -75,7 +75,7 @@ bool simple_neural_network::initialize() {
         }
     }
 
-    cost_function = cnn::cross_entropy_loss;
+    cost_function("cross_entropy_loss");
     layers[0].set_optimizer("relu");
     layers[1].set_optimizer("relu");
     //layers.back().set_optimizer("softmax");

--- a/test/test_neuron.cpp
+++ b/test/test_neuron.cpp
@@ -1,5 +1,15 @@
+#include <cstdlib>
+#include <iostream>
+
 #include "neuron.hpp"
 
-int main() {
-  return 0;
+int main()
+{
+  cnn::Neuron n{1.5f};
+  // note: operator<< for Neuron includes trailing newline
+  std::cout << n << std::flush;
+  // update + stream again
+  n = -n;
+  std::cout << n << std::flush;
+  return EXIT_SUCCESS;
 }

--- a/test/test_optimizer.cpp
+++ b/test/test_optimizer.cpp
@@ -7,8 +7,84 @@
 
 #include <cstdlib>
 #include <iostream>
+#include <numeric>
+#include <type_traits>
+#include <vector>
 
+#include "functions.hpp"
 #include "optimizer.hpp"
+
+namespace {
+
+/**
+ * Ensure the `optimizer` produces the expected activation values.
+ *
+ * @note We have to check the values since comparing the addresses of function
+ *  defined in a shared library is complicated due to thunking on platforms
+ *  like Windows, where modules get the address of the thunk instead of the
+ *  actual function address in the defining DLL.
+ *
+ * @param opt Optimizer instance to check
+ * @returns Number of errors
+ */
+auto check(const cnn::optimizer& opt)
+{
+  auto errs = 0u;
+  // corresponding activation from name
+  auto act = cnn::get_activation(opt.name());
+  // ensure f, g values are as expected on a range of values
+  // note: values are symmetric around zero, e.g. -4.5, -3.5, ... 3.5, 4.5
+  std::vector<cnn::real_type> values(10u);
+  std::iota(values.begin(), values.end(), cnn::real_type{-4.5f});
+  // values should be exactly the same
+  for (auto i = 0u; i < values.size(); i++) {
+    // compute function + gradient values
+    auto v = values[i];
+    auto act_f = act.f(v);
+    auto act_g = act.g(v);
+    auto opt_f = opt(v);
+    auto opt_g = opt.grad(v);
+    // compare function values
+    if (act_f != opt_f) {
+      std::cerr << "ERROR: " << opt << ": act.f(" << v << ") != opt(" <<
+        v << ") [" << act_f << " != " << opt_f << "]" << std::endl;
+      errs++;
+    }
+    // compare gradient values
+    if (act_g != opt_g) {
+      std::cerr << "ERROR: " << opt << ": act.g(" << v << ") != opt.grad(" <<
+        v << ") [" << act_g << " != " << opt_g << "]" << std::endl;
+      errs++;
+    }
+  }
+  // return number of errors
+  return errs;
+}
+
+/**
+ * Ensure `optimizer` objects produce the expected activation values.
+ *
+ * This calls `check()` in a fold expression.
+ *
+ * @tparam Ts `optimizer`
+ *
+ * @param opt_1 First `optimizer` instance
+ * @param opt_2 Second `optimizer` instance
+ * @param opts Additional optimizer instances to check
+ * @returns Number of errors
+ */
+template <typename... Ts>
+auto check(
+  const cnn::optimizer& opt_1,
+  const cnn::optimizer& opt_2,
+  const Ts&... opts)
+{
+  // fold over pack
+  static_assert((std::is_convertible_v<Ts, cnn::optimizer> && ...));
+  return check(opt_1) + check(opt_2) + (check(opts) + ...);
+}
+
+}  // namespace
 
 int main()
 {
@@ -16,10 +92,13 @@ int main()
   cnn::optimizer opt_1{"linear"};
   cnn::optimizer opt_2{"relu"};
   cnn::optimizer opt_3{"sigmoid"};
+  cnn::optimizer opt_4{"softmax"};
   // stream
   std::cout <<
     opt_1 << "\n" <<
     opt_2 << "\n" <<
-    opt_3 << "\n" << std::flush;
-  return EXIT_SUCCESS;
+    opt_3 << "\n" <<
+    opt_4 << "\n" << std::flush;
+  // check values. if no errors, success
+  return !check(opt_1, opt_2, opt_3, opt_4) ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/test/test_optimizer.cpp
+++ b/test/test_optimizer.cpp
@@ -1,6 +1,6 @@
 /**
  * @file test_optimizer.cpp
- * @author David Huang, Derek HUang
+ * @author David Huang, Derek Huang
  * @brief C++ program testing optimizer construction + stream
  * @copyright MIT License
  */

--- a/test/test_optimizer.cpp
+++ b/test/test_optimizer.cpp
@@ -1,7 +1,25 @@
-#include "optimizer.hpp"
-#include "functions.hpp"
+/**
+ * @file test_optimizer.cpp
+ * @author David Huang, Derek HUang
+ * @brief C++ program testing optimizer construction + stream
+ * @copyright MIT License
+ */
 
-int main() {
-  cnn::optimizer optimizer("test", cnn::linear, cnn::derivative_linear);
-  return 0;
+#include <cstdlib>
+#include <iostream>
+
+#include "optimizer.hpp"
+
+int main()
+{
+  // create a few optimizers with different activations
+  cnn::optimizer opt_1{"linear"};
+  cnn::optimizer opt_2{"relu"};
+  cnn::optimizer opt_3{"sigmoid"};
+  // stream
+  std::cout <<
+    opt_1 << "\n" <<
+    opt_2 << "\n" <<
+    opt_3 << "\n" << std::flush;
+  return EXIT_SUCCESS;
 }


### PR DESCRIPTION
## Summary

Enable `optimizer` activation functions and `NeuralNetwork` cost function de-serialization from YAML + cleanup.

## Serialization

One problem with the `test_cnn2_import` test is that after the `simple_neural_network` has its state rehydrated from the YAML archive, the `initialize()` call must still be done to set the `NeuralNetwork` cost function member. Furthermore, any `optimizer` objects in any of the network layers will be default-constructed, i.e. be constructed as having linear activations, which would mess up any network that has nonlinear activation layers, e.g. ReLU, sigmoid, etc.

We solve this problem by adding the `get_activation()` and `get_cost_function()` functions that take a string identifier and return the appropriate function pointer(s), implemented via static `std::map` instances. This allows us to continue to write the string name of the optimizer activation or neural network cost function and then use that name to recover the appropriate function pointers. Note, however, that the inverse mapping is difficult to do, as on Windows, the address of a function exported by a DLL accessed in another DLL/EXE will *not* be the same as taking the address of the function name due to thunks/indirection. Fortunately, we only need name -> function pointer, so we can avoid thinking too much about this.

## Refactoring

This PR also cleans up header includes, which were often far beyond what was actually necessary. For example, [Boost.YML-archive](https://gitlab.com/correaa/boost-archive-yml) headers are unused except in the tests; this means that the `cnnlib` shared library target doesn't actually depend on Boost.YML-archive at all. Furthermore, most of the [Boost.Serialization](https://www.boost.org/doc/libs/latest/libs/serialization/doc/index.html) were also unneeded, and were just clutter.

Note that to reimplement the [de]serialization for the `optimizer` and the `NeuralNetwork` classes, some design changes were made. The `NeuralNetwork` now has a `cost_function_name` member, which is written as a `"cost_function"` field in the YAML file, and is used by the Boost.Serialization `load()` member function with `get_cost_function()` to retrieve the appropriate cost function pointer. The `optimizer` uses the new `activation` structure that has both the activation function + derivative function pointers, and is cleaned up a bit by to use accessors and `operator()` overloading for nicer usage. For both, the [split serialization](https://www.boost.org/doc/libs/latest/libs/serialization/doc/tutorial.html#splitting) approach is taken to support saving a string, and then using the string to map back to the appropriate function pointer[s]. This means that setting the cost function or the optimizer can be done using a string, for example `"mse_loss"`, `"relu"`, etc. although the singular downside is that one can no longer set arbitrary cost or activation functions.

The `test_neuron` and `test_optimizer` tests are also given a bit of substance to ensure the classes work as intended.